### PR TITLE
add pressure computation into turbulence_function

### DIFF
--- a/Simulation1d.pyx
+++ b/Simulation1d.pyx
@@ -36,7 +36,6 @@ class Simulation1d:
         return
 
     def run(self):
-
         while self.TS.t <= self.TS.t_max:
             self.GMV.zero_tendencies()
             self.Case.update_surface(self.GMV, self.TS)
@@ -48,8 +47,6 @@ class Simulation1d:
             self.Turb.update_GMV_diagnostics(self.GMV)
             if np.mod(self.TS.t, self.Stats.frequency) == 0:
                 self.io()
-
-
         return
 
     def initialize_io(self):

--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -130,7 +130,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
     cpdef compute_horizontal_eddy_diffusivities(self, GridMeanVariables GMV)
     cpdef reset_surface_covariance(self, GridMeanVariables GMV, CasesBase Case)
     cpdef compute_pressure_plume_spacing(self, GridMeanVariables GMV,  CasesBase Case)
-    cpdef compute_nh_pressure_sep(self)
+    cpdef compute_nh_pressure(self)
 
     cpdef set_updraft_surface_bc(self, GridMeanVariables GMV, CasesBase Case)
     cpdef decompose_environment(self, GridMeanVariables GMV, whichvals)

--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -7,7 +7,7 @@ from ReferenceState cimport  ReferenceState
 from Cases cimport CasesBase
 from TimeStepping cimport  TimeStepping
 from NetCDFIO cimport NetCDFIO_Stats
-from turbulence_functions cimport entr_struct, entr_in_struct
+from turbulence_functions cimport *
 from Turbulence cimport ParameterizationBase
 
 
@@ -20,11 +20,16 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         EDMF_Environment.EnvironmentVariables EnvVar
         EDMF_Environment.EnvironmentThermodynamics EnvThermo
         entr_struct (*entr_detr_fp) (entr_in_struct entr_in) nogil
+        pressure_buoy_struct (*pressure_func_buoy) (pressure_in_struct press_in) nogil
+        pressure_drag_struct (*pressure_func_drag) (pressure_in_struct press_in) nogil
         bint use_local_micro
         bint similarity_diffusivity
         bint use_steady_updrafts
         bint calc_scalar_var
         bint calc_tke
+
+        char* asp_label
+        double drag_sign
         double surface_area
         double minimum_area
         double entrainment_factor
@@ -36,11 +41,19 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         double pressure_buoy_coeff # Tan et al. 2018: coefficient alpha_b in Eq. 30
         double pressure_drag_coeff # Tan et al. 2018: coefficient alpha_d in Eq. 30
         double [:] pressure_plume_spacing # Tan et al. 2018: coefficient r_d in Eq. 30
+        double pressure_normalmode_coeff1
+        double pressure_normalmode_coeff2
+        double pressure_normalmode_coeff3
         double dt_upd
         double aspect_ratio
         double [:,:] entr_sc
         double [:,:] detr_sc
         double [:,:] nh_pressure
+        double [:,:] nh_pressure_w
+        double [:,:] nh_pressure_b
+        double [:,:] asp_ratio
+        double [:,:] b_coeff
+
         double [:,:] buoyant_frac
         double [:,:] b_mix
         double [:,:] frac_turb_entr
@@ -116,8 +129,9 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
     cpdef compute_eddy_diffusivities_tke(self, GridMeanVariables GMV, CasesBase Case)
     cpdef compute_horizontal_eddy_diffusivities(self, GridMeanVariables GMV)
     cpdef reset_surface_covariance(self, GridMeanVariables GMV, CasesBase Case)
-    cpdef compute_nh_pressure(self)
     cpdef compute_pressure_plume_spacing(self, GridMeanVariables GMV,  CasesBase Case)
+    cpdef compute_nh_pressure_sep(self)
+
     cpdef set_updraft_surface_bc(self, GridMeanVariables GMV, CasesBase Case)
     cpdef decompose_environment(self, GridMeanVariables GMV, whichvals)
     cpdef compute_turbulent_entrainment(self, GridMeanVariables GMV, CasesBase Case)
@@ -160,4 +174,3 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                                 EDMF_Environment.EnvironmentVariable phi_e, EDMF_Environment.EnvironmentVariable psi_e,
                                 EDMF_Environment.EnvironmentVariable_2m covar_e,
                                 double *gmv_phi, double *gmv_psi, double *gmv_covar)
-

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -82,7 +82,40 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             self.entr_detr_fp = entr_detr_b_w2
             print('Turbulence--EDMF_PrognosticTKE: defaulting to cloudy entrainment formulation')
         if(self.calc_tke == False and 'tke' in str(namelist['turbulence']['EDMF_PrognosticTKE']['entrainment'])):
-             sys.exit('Turbulence--EDMF_PrognosticTKE: >>calc_tke<< must be set to True when entrainment is using tke')
+            sys.exit('Turbulence--EDMF_PrognosticTKE: >>calc_tke<< must be set to True when entrainment is using tke')
+
+
+        try:
+            if str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'tan18':
+                self.pressure_func_buoy = pressure_tan18_buoy
+            elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'jia':
+                self.pressure_func_buoy = pressure_jia_buoy
+            else:
+                print('Turbulence--EDMF_PrognosticTKE: pressure closure in namelist option is not recognized')
+        except:
+            self.pressure_func_buoy = pressure_tan18_buoy
+            print('Turbulence--EDMF_PrognosticTKE: defaulting to pressure closure Tan2018')
+
+        self.drag_sign = 0.0
+        try:
+            if str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag']) == 'tan18':
+                self.pressure_func_drag = pressure_tan18_drag
+            elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag']) == 'jia':
+                self.pressure_func_drag = pressure_jia_drag
+            elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag']) == 'jia_signdf':
+                self.pressure_func_drag = pressure_jia_drag
+                self.drag_sign = 1.0
+            else:
+                print('Turbulence--EDMF_PrognosticTKE: pressure closure in namelist option is not recognized')
+        except:
+            self.pressure_func_drag = pressure_tan18_drag
+            print('Turbulence--EDMF_PrognosticTKE: defaulting to pressure closure Tan2018')
+
+        try:
+            self.asp_label = namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label']
+        except:
+            self.asp_label = 'const'
+            print('Turbulence--EDMF_PrognosticTKE: H/2R defaulting to constant')
 
         try:
             self.similarity_diffusivity = namelist['turbulence']['EDMF_PrognosticTKE']['use_similarity_diffusivity']
@@ -117,6 +150,10 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         self.turbulent_entrainment_factor = paramlist['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor']
         self.pressure_buoy_coeff = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff']
         self.aspect_ratio = paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio']
+
+        self.pressure_normalmode_coeff1 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1']
+        self.pressure_normalmode_coeff2 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2']
+        self.pressure_normalmode_coeff3 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3']
         # "Legacy" coefficients used by the steady updraft routine
         self.vel_buoy_coeff = 1.0-self.pressure_buoy_coeff
         if self.calc_tke == True:
@@ -157,6 +194,11 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
 
         # Pressure term in updraft vertical momentum equation
         self.nh_pressure = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.nh_pressure_b = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.nh_pressure_w = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.asp_ratio = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.b_coeff = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+
         # Mass flux
         self.m = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double, order='c')
 
@@ -216,6 +258,11 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         Stats.add_profile('entrainment_sc')
         Stats.add_profile('detrainment_sc')
         Stats.add_profile('nh_pressure')
+        Stats.add_profile('nh_pressure_w')
+        Stats.add_profile('nh_pressure_b')
+        Stats.add_profile('asp_ratio')
+        Stats.add_profile('b_coeff')
+
         Stats.add_profile('horizontal_KM')
         Stats.add_profile('horizontal_KH')
         Stats.add_profile('buoyant_frac')
@@ -286,6 +333,11 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             Py_ssize_t kmax = self.Gr.nzg-self.Gr.gw
             double [:] mean_entr_sc = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_nh_pressure = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_nh_pressure_w = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_nh_pressure_b = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_asp_ratio = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_b_coeff = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+
             double [:] mean_detr_sc = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] massflux = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mf_h = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
@@ -316,6 +368,11 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                         mean_entr_sc[k] += self.UpdVar.Area.values[i,k] * self.entr_sc[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_detr_sc[k] += self.UpdVar.Area.values[i,k] * self.detr_sc[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_nh_pressure[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_nh_pressure_b[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_b[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_nh_pressure_w[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_w[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_asp_ratio[k] += self.UpdVar.Area.values[i,k] * self.asp_ratio[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_b_coeff[k] += self.UpdVar.Area.values[i,k] * self.b_coeff[i,k]/self.UpdVar.Area.bulkvalues[k]
+
                         mean_frac_turb_entr_full[k] += self.UpdVar.Area.values[i,k] * self.frac_turb_entr_full[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_frac_turb_entr[k] += self.UpdVar.Area.values[i,k] * self.frac_turb_entr[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_turb_entr_W[k] += self.UpdVar.Area.values[i,k] * self.turb_entr_W[i,k]/self.UpdVar.Area.bulkvalues[k]
@@ -338,6 +395,11 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         Stats.write_profile('buoyant_frac', mean_buoyant_frac[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('b_mix', mean_b_mix[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('nh_pressure', mean_nh_pressure[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('nh_pressure_w', mean_nh_pressure_w[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('nh_pressure_b', mean_nh_pressure_b[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('asp_ratio', mean_asp_ratio[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('b_coeff', mean_b_coeff[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+
         Stats.write_profile('massflux', massflux[self.Gr.gw:self.Gr.nzg-self.Gr.gw ])
         Stats.write_profile('massflux_h', mf_h[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('massflux_qt', mf_qt[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
@@ -482,7 +544,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             self.compute_entrainment_detrainment(GMV, Case)
             self.compute_horizontal_eddy_diffusivities(GMV)
             self.compute_turbulent_entrainment(GMV,Case)
-            self.compute_nh_pressure()
+            self.compute_nh_pressure_sep()
             self.solve_updraft_velocity_area(GMV,TS)
             self.solve_updraft_scalars(GMV, Case, TS)
             self.UpdVar.set_values_with_new()
@@ -1234,23 +1296,56 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             self.pressure_plume_spacing[i] = fmax(self.aspect_ratio*self.UpdVar.updraft_top[i],500.0)
         return
 
-    cpdef compute_nh_pressure(self):
+    cpdef compute_nh_pressure_sep(self):
         cdef:
-            Py_ssize_t i, k
-            double a_k, B_k, press_buoy, press_drag
-        for k in xrange(self.Gr.gw, self.Gr.nzg-self.Gr.gw):
-            for i in xrange(self.n_updrafts):
-                a_k = interp2pt(self.UpdVar.Area.values[i,k], self.UpdVar.Area.values[i,k+1])
-                B_k = interp2pt(self.UpdVar.B.values[i,k], self.UpdVar.B.values[i,k+1])
-                if a_k>0.0:
-                    press_buoy =  -1.0 * self.Ref.rho0[k] * a_k * B_k * self.pressure_buoy_coeff
-                    press_drag = -1.0 * self.Ref.rho0[k] * sqrt(a_k) * (1.0/self.pressure_plume_spacing[i]
-                                    * (self.UpdVar.W.values[i,k] -self.EnvVar.W.values[k])*fabs(self.UpdVar.W.values[i,k] -self.EnvVar.W.values[k]))
-                    self.nh_pressure[i,k] = press_buoy + press_drag
+            Py_ssize_t i,k
+            pressure_buoy_struct ret_b
+            pressure_drag_struct ret_w
+            pressure_in_struct input
+
+        input.asp_label = self.asp_label
+        for i in xrange(self.n_updrafts):
+            input.H = self.UpdVar.updraft_top[i]
+            input.a_med = np.median(np.argwhere(self.UpdVar.Area.values[i,self.Gr.gw:self.Gr.nzg-self.Gr.gw]))
+            for k in xrange(self.Gr.gw, self.Gr.nzg-self.Gr.gw):
+                input.a_kfull = interp2pt(self.UpdVar.Area.values[i,k], self.UpdVar.Area.values[i,k+1])
+                input.dzi = self.Gr.dzi
+
+                input.a_khalf = self.UpdVar.Area.values[i,k]
+                input.a_kphalf = self.UpdVar.Area.values[i,k+1]
+                input.b_kfull = interp2pt(self.UpdVar.B.values[i,k], self.UpdVar.B.values[i,k+1])
+                input.rho0_kfull = self.Ref.rho0[k]
+                input.bcoeff_tan18 = self.pressure_buoy_coeff
+                input.alpha1 = self.pressure_normalmode_coeff1
+                input.alpha2 = self.pressure_normalmode_coeff2
+                input.beta = self.pressure_normalmode_coeff3
+                input.rd = self.pressure_plume_spacing[i]
+                input.w_kfull = self.UpdVar.W.values[i,k]
+                input.w_khalf = interp2pt(self.UpdVar.W.values[i,k], self.UpdVar.W.values[i,k-1])
+                input.w_kphalf = interp2pt(self.UpdVar.W.values[i,k], self.UpdVar.W.values[i,k+1])
+                input.w_kenv = self.EnvVar.W.values[k]
+                input.drag_sign = self.drag_sign
+
+                if input.a_kfull>0.0:
+                    ret_b = self.pressure_func_buoy(input)
+                    ret_w = self.pressure_func_drag(input)
+                    self.nh_pressure_b[i,k] = ret_b.nh_pressure_b
+                    self.nh_pressure_w[i,k] = ret_w.nh_pressure_w
+
+                    self.b_coeff[i,k] = ret_b.b_coeff
+                    self.asp_ratio[i,k] = ret_b.asp_ratio
+
                 else:
-                    self.nh_pressure[i,k] = 0.0
+                    self.nh_pressure_b[i,k] = 0.0
+                    self.nh_pressure_w[i,k] = 0.0
+
+                    self.b_coeff[i,k] = 0.0
+                    self.asp_ratio[i,k] = 0.0
+
+                self.nh_pressure[i,k] = self.nh_pressure_b[i,k] + self.nh_pressure_w[i,k]
 
         return
+
 
     cpdef zero_area_fraction_cleanup(self, GridMeanVariables GMV):
         cdef:

--- a/generate_namelist.py
+++ b/generate_namelist.py
@@ -74,6 +74,10 @@ def Soares():
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
 
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
+
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
 
@@ -118,6 +122,10 @@ def Bomex():
     namelist['turbulence']['EDMF_PrognosticTKE']['calculate_tke'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
+
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
 
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
@@ -164,6 +172,10 @@ def life_cycle_Tan2018():
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
 
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
+
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
 
@@ -208,6 +220,10 @@ def Rico():
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
 
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
+
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
 
@@ -237,7 +253,7 @@ def TRMM_LBA(): # yair
 
     namelist['time_stepping'] = {}
     namelist['time_stepping']['dt'] = 30.0
-    namelist['time_stepping']['t_max'] = 21590.0
+    namelist['time_stepping']['t_max'] = 21600.0
 
     namelist['turbulence'] = {}
     namelist['turbulence']['scheme'] = 'EDMF_PrognosticTKE'
@@ -252,6 +268,10 @@ def TRMM_LBA(): # yair
     namelist['turbulence']['EDMF_PrognosticTKE']['calculate_tke'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
+
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
 
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
@@ -297,6 +317,10 @@ def ARM_SGP():
     namelist['turbulence']['EDMF_PrognosticTKE']['calculate_tke'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
+
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
 
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
@@ -344,6 +368,10 @@ def GATE_III(): # yair
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
 
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
+
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
 
@@ -388,6 +416,10 @@ def DYCOMS_RF01():
     namelist['turbulence']['EDMF_PrognosticTKE']['calculate_tke'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
+
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
 
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
@@ -434,6 +466,10 @@ def GABLS():
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
 
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
+
     namelist['output'] = {}
     namelist['output']['output_root'] = './'
 
@@ -479,6 +515,10 @@ def SP():
     namelist['turbulence']['EDMF_PrognosticTKE']['calculate_tke'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['calc_scalar_var'] = True
     namelist['turbulence']['EDMF_PrognosticTKE']['mixing_length'] = 'sbtd_eq'
+
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag'] = 'tan18'
+    namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_asp_label'] = 'median'
 
     namelist['output'] = {}
     namelist['output']['output_root'] = './'

--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -82,6 +82,9 @@ def defaults():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
     return  paramlist
 
 
@@ -107,6 +110,10 @@ def Soares():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+
     return paramlist
 
 
@@ -131,6 +138,10 @@ def Bomex():
     paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_erf_const'] = 0.5
     paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff'] = 1.0/3.0
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
+
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
 
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
@@ -161,6 +172,10 @@ def life_cycle_Tan2018():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+
     return  paramlist
 
 def Rico():
@@ -187,6 +202,10 @@ def Rico():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.02
 
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+
     return  paramlist
 
 
@@ -211,6 +230,11 @@ def TRMM_LBA():
     paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_erf_const'] = 0.5
     paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff'] = 1.0/3.0
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
+
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.01
 
@@ -240,6 +264,10 @@ def ARM_SGP():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+
     return  paramlist
 
 
@@ -266,6 +294,10 @@ def GATE_III():
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
+
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
 
     return  paramlist
 
@@ -294,6 +326,10 @@ def DYCOMS_RF01():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+
     return  paramlist
 
 def GABLS():
@@ -319,6 +355,10 @@ def GABLS():
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
+
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
 
     return  paramlist
 
@@ -346,6 +386,10 @@ def SP():
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
+
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
 
     return  paramlist
 

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -103,8 +103,8 @@ cdef buoyant_stract buoyancy_sorting_mean(entr_in_struct entr_in) nogil
 
 cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
 cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil
-cdef pressure_buoy_struct pressure_jia_buoy(pressure_in_struct press_in) nogil
-cdef pressure_drag_struct pressure_jia_drag(pressure_in_struct press_in) nogil
+cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) nogil
+cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) nogil
 
 cdef double get_wstar(double bflux, double zi )
 cdef double get_inversion(double *theta_rho, double *u, double *v, double *z_half,

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -60,6 +60,35 @@ cdef struct entr_in_struct:
     double poisson
     long quadrature_order
 
+cdef struct pressure_in_struct:
+    double H
+    char* asp_label
+    double a_med
+    double a_kfull
+    double a_khalf
+    double a_kphalf
+    double b_kfull
+    double rho0_kfull
+    double bcoeff_tan18
+    double alpha1
+    double alpha2
+    double beta
+    double rd
+    double w_kfull
+    double w_khalf
+    double w_kphalf
+    double w_kenv
+    double dzi
+    double drag_sign
+
+cdef struct pressure_buoy_struct:
+    double asp_ratio
+    double b_coeff
+    double nh_pressure_b
+
+cdef struct pressure_drag_struct:
+    double nh_pressure_w
+
 cdef entr_struct entr_detr_dry(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_inverse_z(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_inverse_w(entr_in_struct entr_in) nogil
@@ -71,6 +100,12 @@ cdef entr_struct entr_detr_suselj(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_none(entr_in_struct entr_in) nogil
 cdef double buoyancy_sorting(entr_in_struct entr_in) nogil
 cdef buoyant_stract buoyancy_sorting_mean(entr_in_struct entr_in) nogil
+
+cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
+cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil
+cdef pressure_buoy_struct pressure_jia_buoy(pressure_in_struct press_in) nogil
+cdef pressure_drag_struct pressure_jia_drag(pressure_in_struct press_in) nogil
+
 cdef double get_wstar(double bflux, double zi )
 cdef double get_inversion(double *theta_rho, double *u, double *v, double *z_half,
                           Py_ssize_t kmin, Py_ssize_t kmax, double Ri_bulk_crit)

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -237,6 +237,59 @@ cdef entr_struct entr_detr_none(entr_in_struct entr_in)nogil:
 
     return  _ret
 
+cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil:
+    cdef:
+        pressure_buoy_struct _ret
+
+    with gil:
+        if press_in.asp_label.encode('utf-8') == 'z_dependent':
+            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
+        elif press_in.asp_label.encode('utf-8') == 'median':
+            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_med)/press_in.rd
+        elif press_in.asp_label.encode('utf-8') == 'const':
+            _ret.asp_ratio = 1.72
+
+    _ret.b_coeff = press_in.bcoeff_tan18
+    _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff
+
+    return _ret
+
+cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil:
+    cdef:
+        pressure_drag_struct _ret
+
+    _ret.nh_pressure_w = -1.0 * press_in.rho0_kfull * sqrt(press_in.a_kfull) * (1.0/press_in.rd
+                         * (press_in.w_kfull - press_in.w_kenv)*fabs(press_in.w_kfull - press_in.w_kenv))
+
+    return _ret
+
+cdef pressure_buoy_struct pressure_jia_buoy(pressure_in_struct press_in) nogil:
+    cdef:
+        pressure_buoy_struct _ret
+
+    with gil:
+        if press_in.asp_label.encode('utf-8') == 'z_dependent':
+            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
+        elif press_in.asp_label.encode('utf-8') == 'median':
+            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_med)/press_in.rd
+        elif press_in.asp_label.encode('utf-8') == 'const':
+            _ret.asp_ratio = 1.72
+
+    _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*_ret.asp_ratio**2 )
+    _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff
+
+    return _ret
+
+cdef pressure_drag_struct pressure_jia_drag(pressure_in_struct press_in) nogil:
+    cdef:
+        pressure_drag_struct _ret
+    _ret.nh_pressure_w = press_in.rho0_kfull * press_in.a_kfull * press_in.beta * (1.0/press_in.a_kfull*(
+                         press_in.a_kphalf*press_in.w_kphalf**2 - press_in.a_khalf*press_in.w_khalf**2 )*press_in.dzi
+                         - 0.5 * ( press_in.w_kphalf**2 - press_in.w_khalf**2 ) * press_in.dzi )
+    if press_in.drag_sign == 1.0:
+        _ret.nh_pressure_w = -fabs(_ret.nh_pressure_w)
+    return _ret
+
 # convective velocity scale
 cdef double get_wstar(double bflux, double zi ):
     return cbrt(fmax(bflux * zi, 0.0))
@@ -400,5 +453,3 @@ cdef bint set_cloudbase_flag(double ql, bint current_flag) nogil:
     else:
         new_flag = current_flag
     return  new_flag
-
-

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -242,11 +242,11 @@ cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
         pressure_buoy_struct _ret
 
     with gil:
-        if press_in.asp_label.encode('utf-8') == 'z_dependent':
+        if str(press_in.asp_label) == 'z_dependent':
             _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
-        elif press_in.asp_label.encode('utf-8') == 'median':
+        elif str(press_in.asp_label) == 'median':
             _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_med)/press_in.rd
-        elif press_in.asp_label.encode('utf-8') == 'const':
+        elif str(press_in.asp_label) == 'const':
             _ret.asp_ratio = 1.72
 
     _ret.b_coeff = press_in.bcoeff_tan18

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -263,7 +263,7 @@ cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil
 
     return _ret
 
-cdef pressure_buoy_struct pressure_jia_buoy(pressure_in_struct press_in) nogil:
+cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) nogil:
     cdef:
         pressure_buoy_struct _ret
 
@@ -280,7 +280,7 @@ cdef pressure_buoy_struct pressure_jia_buoy(pressure_in_struct press_in) nogil:
 
     return _ret
 
-cdef pressure_drag_struct pressure_jia_drag(pressure_in_struct press_in) nogil:
+cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) nogil:
     cdef:
         pressure_drag_struct _ret
     _ret.nh_pressure_w = press_in.rho0_kfull * press_in.a_kfull * press_in.beta * (1.0/press_in.a_kfull*(


### PR DESCRIPTION
- move pressure computation into turbulence_functions.pyx
- separate pressure computation into buoy and drag term into two functions, and archive them in output file
- add namelist options for computations of buoy and drag terms, and set default to be the formula in Tan et al 18.
- add three additional parameters in generate_paramlist.py for the pressure computation thru normal mode derivation
- add b_coeff into output file
- add H/2R into output file