### PR TITLE
update pressure closure

### DIFF
--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -21,6 +21,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         EDMF_Environment.EnvironmentThermodynamics EnvThermo
         entr_struct (*entr_detr_fp) (entr_in_struct entr_in) nogil
         pressure_buoy_struct (*pressure_func_buoy) (pressure_in_struct press_in) nogil
+        pressure_buoy_struct (*pressure_func_buoysin) (pressure_in_struct press_in) nogil
         pressure_drag_struct (*pressure_func_drag) (pressure_in_struct press_in) nogil
         bint use_local_micro
         bint similarity_diffusivity
@@ -28,7 +29,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         bint calc_scalar_var
         bint calc_tke
 
-        char* asp_label
+        char *asp_label
         double drag_sign
         double surface_area
         double minimum_area
@@ -44,12 +45,14 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         double pressure_normalmode_coeff1
         double pressure_normalmode_coeff2
         double pressure_normalmode_coeff3
+        double pressure_normalmode_coeff4
         double dt_upd
         double aspect_ratio
         double [:,:] entr_sc
         double [:,:] detr_sc
         double [:,:] nh_pressure
-        double [:,:] nh_pressure_w
+        double [:,:] nh_pressure_w1
+        double [:,:] nh_pressure_w2
         double [:,:] nh_pressure_b
         double [:,:] asp_ratio
         double [:,:] b_coeff

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -90,6 +90,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                 self.pressure_func_buoy = pressure_tan18_buoy
             elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'normalmode':
                 self.pressure_func_buoy = pressure_normalmode_buoy
+            elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'normalmode_buoysin':
+                self.pressure_func_buoy = pressure_normalmode_buoysin
             else:
                 print('Turbulence--EDMF_PrognosticTKE: pressure closure in namelist option is not recognized')
         except:
@@ -155,10 +157,12 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             self.pressure_normalmode_coeff1 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1']
             self.pressure_normalmode_coeff2 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2']
             self.pressure_normalmode_coeff3 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3']
+            self.pressure_normalmode_coeff4 = paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4']
         except:
             self.pressure_normalmode_coeff1 = self.pressure_buoy_coeff
             self.pressure_normalmode_coeff2 = 0.0
-            self.pressure_normalmode_coeff3 = 1.0
+            self.pressure_normalmode_coeff3 = 0.0
+            self.pressure_normalmode_coeff4 = 1.0
             print 'Using (Tan et al, 2018) parameters as default for Normal Mode pressure formula'
 
         # "Legacy" coefficients used by the steady updraft routine
@@ -202,7 +206,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         # Pressure term in updraft vertical momentum equation
         self.nh_pressure = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
         self.nh_pressure_b = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
-        self.nh_pressure_w = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.nh_pressure_w1 = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.nh_pressure_w2 = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
         self.asp_ratio = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
         self.b_coeff = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
 
@@ -265,7 +270,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         Stats.add_profile('entrainment_sc')
         Stats.add_profile('detrainment_sc')
         Stats.add_profile('nh_pressure')
-        Stats.add_profile('nh_pressure_w')
+        Stats.add_profile('nh_pressure_w1')
+        Stats.add_profile('nh_pressure_w2')
         Stats.add_profile('nh_pressure_b')
         Stats.add_profile('asp_ratio')
         Stats.add_profile('b_coeff')
@@ -340,7 +346,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             Py_ssize_t kmax = self.Gr.nzg-self.Gr.gw
             double [:] mean_entr_sc = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_nh_pressure = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
-            double [:] mean_nh_pressure_w = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_nh_pressure_w1 = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_nh_pressure_w2 = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_nh_pressure_b = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_asp_ratio = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_b_coeff = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
@@ -376,7 +383,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                         mean_detr_sc[k] += self.UpdVar.Area.values[i,k] * self.detr_sc[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_nh_pressure[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_nh_pressure_b[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_b[i,k]/self.UpdVar.Area.bulkvalues[k]
-                        mean_nh_pressure_w[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_w[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_nh_pressure_w1[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_w1[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_nh_pressure_w2[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_w2[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_asp_ratio[k] += self.UpdVar.Area.values[i,k] * self.asp_ratio[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_b_coeff[k] += self.UpdVar.Area.values[i,k] * self.b_coeff[i,k]/self.UpdVar.Area.bulkvalues[k]
 
@@ -402,7 +410,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         Stats.write_profile('buoyant_frac', mean_buoyant_frac[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('b_mix', mean_b_mix[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('nh_pressure', mean_nh_pressure[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
-        Stats.write_profile('nh_pressure_w', mean_nh_pressure_w[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('nh_pressure_w1', mean_nh_pressure_w1[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('nh_pressure_w2', mean_nh_pressure_w2[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('nh_pressure_b', mean_nh_pressure_b[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('asp_ratio', mean_asp_ratio[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('b_coeff', mean_b_coeff[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
@@ -1305,7 +1314,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
 
     cpdef compute_nh_pressure(self):
         cdef:
-            Py_ssize_t i,k
+            Py_ssize_t i,k, alen
             pressure_buoy_struct ret_b
             pressure_drag_struct ret_w
             pressure_in_struct input
@@ -1313,10 +1322,12 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         input.asp_label = self.asp_label
         for i in xrange(self.n_updrafts):
             input.H = self.UpdVar.updraft_top[i]
-            input.a_med = np.median(np.argwhere(self.UpdVar.Area.values[i,self.Gr.gw:self.Gr.nzg-self.Gr.gw]))
+            alen = len(np.argwhere(self.UpdVar.Area.values[i,self.Gr.gw:self.Gr.nzg-self.Gr.gw]))
+            input.a_med = np.median(self.UpdVar.Area.values[i,self.Gr.gw:self.Gr.nzg-self.Gr.gw][:alen])
             for k in xrange(self.Gr.gw, self.Gr.nzg-self.Gr.gw):
                 input.a_kfull = interp2pt(self.UpdVar.Area.values[i,k], self.UpdVar.Area.values[i,k+1])
                 input.dzi = self.Gr.dzi
+                input.z_full = self.Gr.z[k]
 
                 input.a_khalf = self.UpdVar.Area.values[i,k]
                 input.a_kphalf = self.UpdVar.Area.values[i,k+1]
@@ -1326,6 +1337,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                 input.alpha1 = self.pressure_normalmode_coeff1
                 input.alpha2 = self.pressure_normalmode_coeff2
                 input.beta = self.pressure_normalmode_coeff3
+                input.beta2 = self.pressure_normalmode_coeff4
                 input.rd = self.pressure_plume_spacing[i]
                 input.w_kfull = self.UpdVar.W.values[i,k]
                 input.w_khalf = interp2pt(self.UpdVar.W.values[i,k], self.UpdVar.W.values[i,k-1])
@@ -1337,19 +1349,21 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                     ret_b = self.pressure_func_buoy(input)
                     ret_w = self.pressure_func_drag(input)
                     self.nh_pressure_b[i,k] = ret_b.nh_pressure_b
-                    self.nh_pressure_w[i,k] = ret_w.nh_pressure_w
+                    self.nh_pressure_w1[i,k] = ret_w.nh_pressure_w1
+                    self.nh_pressure_w2[i,k] = ret_w.nh_pressure_w2
 
                     self.b_coeff[i,k] = ret_b.b_coeff
                     self.asp_ratio[i,k] = ret_b.asp_ratio
 
                 else:
                     self.nh_pressure_b[i,k] = 0.0
-                    self.nh_pressure_w[i,k] = 0.0
+                    self.nh_pressure_w1[i,k] = 0.0
+                    self.nh_pressure_w2[i,k] = 0.0
 
                     self.b_coeff[i,k] = 0.0
                     self.asp_ratio[i,k] = 0.0
 
-                self.nh_pressure[i,k] = self.nh_pressure_b[i,k] + self.nh_pressure_w[i,k]
+                self.nh_pressure[i,k] = self.nh_pressure_b[i,k] + self.nh_pressure_w1[i,k] + self.nh_pressure_w2[i,k]
 
         return
 

--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -82,9 +82,10 @@ def defaults():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
     return  paramlist
 
 
@@ -110,9 +111,10 @@ def Soares():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return paramlist
 
@@ -139,9 +141,10 @@ def Bomex():
     paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff'] = 1.0/3.0
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
@@ -172,9 +175,10 @@ def life_cycle_Tan2018():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return  paramlist
 
@@ -202,9 +206,10 @@ def Rico():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.02
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return  paramlist
 
@@ -231,9 +236,10 @@ def TRMM_LBA():
     paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff'] = 1.0/3.0
     paramlist['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.01
@@ -264,9 +270,10 @@ def ARM_SGP():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return  paramlist
 
@@ -295,9 +302,10 @@ def GATE_III():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return  paramlist
 
@@ -326,9 +334,10 @@ def DYCOMS_RF01():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return  paramlist
 
@@ -356,9 +365,10 @@ def GABLS():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff4'] = 0.375
 
     return  paramlist
 
@@ -387,9 +397,9 @@ def SP():
     paramlist['turbulence']['updraft_microphysics'] = {}
     paramlist['turbulence']['updraft_microphysics']['max_supersaturation'] = 0.1
 
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 2.45
-    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.58
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
+    paramlist['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.0
 
     return  paramlist
 

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -73,12 +73,14 @@ cdef struct pressure_in_struct:
     double alpha1
     double alpha2
     double beta
+    double beta2
     double rd
     double w_kfull
     double w_khalf
     double w_kphalf
     double w_kenv
     double dzi
+    double z_full
     double drag_sign
 
 cdef struct pressure_buoy_struct:
@@ -87,7 +89,8 @@ cdef struct pressure_buoy_struct:
     double nh_pressure_b
 
 cdef struct pressure_drag_struct:
-    double nh_pressure_w
+    double nh_pressure_w1
+    double nh_pressure_w2
 
 cdef entr_struct entr_detr_dry(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_inverse_z(entr_in_struct entr_in) nogil
@@ -104,6 +107,7 @@ cdef buoyant_stract buoyancy_sorting_mean(entr_in_struct entr_in) nogil
 cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
 cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil
 cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) nogil
+cdef pressure_buoy_struct pressure_normalmode_buoysin(pressure_in_struct press_in) nogil
 cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) nogil
 
 cdef double get_wstar(double bflux, double zi )

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -242,7 +242,6 @@ cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
         pressure_buoy_struct _ret
 
     with gil:
-        print press_in.asp_label
         if str(press_in.asp_label) == 'z_dependent':
             _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
         elif str(press_in.asp_label) == 'median':
@@ -271,7 +270,6 @@ cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) 
         pressure_buoy_struct _ret
 
     with gil:
-        print press_in.asp_label
         if press_in.asp_label.encode('utf-8') == 'z_dependent':
             _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
         elif press_in.asp_label.encode('utf-8') == 'median':


### PR DESCRIPTION
pressure gradient in w equation is closed with buoy+adv+drag while the adv term can provide accelerate near cloud base as observed in LES results

In namelist file, if "pressure_closure_drag" is set to "tan18", then the adv term is set to zero and the formula is identical to the old version.

Another buoyancy calc function is added where the buoy contribution to pressure gradient is scaled by sin(z/H) at each altitude, H is the height of updraft top. 