### PR TITLE
rename coefficients used in pressure closure in the namelist generation code

### DIFF
--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -29,7 +29,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         bint calc_scalar_var
         bint calc_tke
 
-        char *asp_label
+        str asp_label
         double drag_sign
         double surface_area
         double minimum_area

--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -30,7 +30,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         bint calc_tke
 
         str asp_label
-        double drag_sign
+        bint drag_sign
         double surface_area
         double minimum_area
         double entrainment_factor

--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -51,8 +51,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         double [:,:] entr_sc
         double [:,:] detr_sc
         double [:,:] nh_pressure
-        double [:,:] nh_pressure_w1
-        double [:,:] nh_pressure_w2
+        double [:,:] nh_pressure_adv
+        double [:,:] nh_pressure_drag
         double [:,:] nh_pressure_b
         double [:,:] asp_ratio
         double [:,:] b_coeff

--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -42,10 +42,10 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         double pressure_buoy_coeff # Tan et al. 2018: coefficient alpha_b in Eq. 30
         double pressure_drag_coeff # Tan et al. 2018: coefficient alpha_d in Eq. 30
         double [:] pressure_plume_spacing # Tan et al. 2018: coefficient r_d in Eq. 30
-        double pressure_normalmode_coeff1
-        double pressure_normalmode_coeff2
-        double pressure_normalmode_coeff3
-        double pressure_normalmode_coeff4
+        double pressure_normalmode_buoy_coeff1
+        double pressure_normalmode_buoy_coeff2
+        double pressure_normalmode_adv_coeff
+        double pressure_normalmode_drag_coeff
         double dt_upd
         double aspect_ratio
         double [:,:] entr_sc

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -212,8 +212,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         # Pressure term in updraft vertical momentum equation
         self.nh_pressure = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
         self.nh_pressure_b = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
-        self.nh_pressure_w1 = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
-        self.nh_pressure_w2 = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.nh_pressure_adv = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
+        self.nh_pressure_drag = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
         self.asp_ratio = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
         self.b_coeff = np.zeros((self.n_updrafts, Gr.nzg),dtype=np.double,order='c')
 
@@ -276,8 +276,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         Stats.add_profile('entrainment_sc')
         Stats.add_profile('detrainment_sc')
         Stats.add_profile('nh_pressure')
-        Stats.add_profile('nh_pressure_w1')
-        Stats.add_profile('nh_pressure_w2')
+        Stats.add_profile('nh_pressure_adv')
+        Stats.add_profile('nh_pressure_drag')
         Stats.add_profile('nh_pressure_b')
         Stats.add_profile('asp_ratio')
         Stats.add_profile('b_coeff')
@@ -352,8 +352,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             Py_ssize_t kmax = self.Gr.nzg-self.Gr.gw
             double [:] mean_entr_sc = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_nh_pressure = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
-            double [:] mean_nh_pressure_w1 = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
-            double [:] mean_nh_pressure_w2 = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_nh_pressure_adv = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
+            double [:] mean_nh_pressure_drag = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_nh_pressure_b = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_asp_ratio = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
             double [:] mean_b_coeff = np.zeros((self.Gr.nzg,), dtype=np.double, order='c')
@@ -389,8 +389,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                         mean_detr_sc[k] += self.UpdVar.Area.values[i,k] * self.detr_sc[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_nh_pressure[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_nh_pressure_b[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_b[i,k]/self.UpdVar.Area.bulkvalues[k]
-                        mean_nh_pressure_w1[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_w1[i,k]/self.UpdVar.Area.bulkvalues[k]
-                        mean_nh_pressure_w2[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_w2[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_nh_pressure_adv[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_adv[i,k]/self.UpdVar.Area.bulkvalues[k]
+                        mean_nh_pressure_drag[k] += self.UpdVar.Area.values[i,k] * self.nh_pressure_drag[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_asp_ratio[k] += self.UpdVar.Area.values[i,k] * self.asp_ratio[i,k]/self.UpdVar.Area.bulkvalues[k]
                         mean_b_coeff[k] += self.UpdVar.Area.values[i,k] * self.b_coeff[i,k]/self.UpdVar.Area.bulkvalues[k]
 
@@ -416,8 +416,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         Stats.write_profile('buoyant_frac', mean_buoyant_frac[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('b_mix', mean_b_mix[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('nh_pressure', mean_nh_pressure[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
-        Stats.write_profile('nh_pressure_w1', mean_nh_pressure_w1[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
-        Stats.write_profile('nh_pressure_w2', mean_nh_pressure_w2[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('nh_pressure_adv', mean_nh_pressure_adv[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
+        Stats.write_profile('nh_pressure_drag', mean_nh_pressure_drag[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('nh_pressure_b', mean_nh_pressure_b[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('asp_ratio', mean_asp_ratio[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
         Stats.write_profile('b_coeff', mean_b_coeff[self.Gr.gw:self.Gr.nzg-self.Gr.gw])
@@ -1355,21 +1355,21 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                     ret_b = self.pressure_func_buoy(input)
                     ret_w = self.pressure_func_drag(input)
                     self.nh_pressure_b[i,k] = ret_b.nh_pressure_b
-                    self.nh_pressure_w1[i,k] = ret_w.nh_pressure_w1
-                    self.nh_pressure_w2[i,k] = ret_w.nh_pressure_w2
+                    self.nh_pressure_adv[i,k] = ret_w.nh_pressure_adv
+                    self.nh_pressure_drag[i,k] = ret_w.nh_pressure_drag
 
                     self.b_coeff[i,k] = ret_b.b_coeff
                     self.asp_ratio[i,k] = ret_b.asp_ratio
 
                 else:
                     self.nh_pressure_b[i,k] = 0.0
-                    self.nh_pressure_w1[i,k] = 0.0
-                    self.nh_pressure_w2[i,k] = 0.0
+                    self.nh_pressure_adv[i,k] = 0.0
+                    self.nh_pressure_drag[i,k] = 0.0
 
                     self.b_coeff[i,k] = 0.0
                     self.asp_ratio[i,k] = 0.0
 
-                self.nh_pressure[i,k] = self.nh_pressure_b[i,k] + self.nh_pressure_w1[i,k] + self.nh_pressure_w2[i,k]
+                self.nh_pressure[i,k] = self.nh_pressure_b[i,k] + self.nh_pressure_adv[i,k] + self.nh_pressure_drag[i,k]
 
         return
 

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -98,7 +98,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             self.pressure_func_buoy = pressure_tan18_buoy
             print('Turbulence--EDMF_PrognosticTKE: defaulting to pressure closure Tan2018')
 
-        self.drag_sign = 0.0
+        self.drag_sign = False
         try:
             if str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag']) == 'tan18':
                 self.pressure_func_drag = pressure_tan18_drag
@@ -106,7 +106,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                 self.pressure_func_drag = pressure_normalmode_drag
             elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_drag']) == 'normalmode_signdf':
                 self.pressure_func_drag = pressure_normalmode_drag
-                self.drag_sign = 1.0
+                self.drag_sign = True
             else:
                 print('Turbulence--EDMF_PrognosticTKE: pressure closure in namelist option is not recognized')
         except:

--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -50,13 +50,15 @@ def main():
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['detrainment_factor'] = 3.0
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor'] = 0.05
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_erf_const'] = 0.5
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff'] = 1.0/3.0
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['aspect_ratio'] = 0.25
 
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff1'] = 1.0/3.0
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff2'] = 0.0
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 0.75
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_coeff3'] = 1.0
+    # TODO: merge the tan18 buoyancy forluma into normalmode formula -> simply set buoy_coeff1 as 1./3. and buoy_coeff2 as 0.
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_buoy_coeff'] = 1.0/3.0
+
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_buoy_coeff1'] = 1.0/3.0
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_buoy_coeff2'] = 0.0
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_adv_coeff'] = 0.75
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_drag_coeff'] = 1.0
 
     if case_name == 'Soares':
         paramlist = Soares(paramlist_defaults)

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -61,8 +61,8 @@ cdef struct entr_in_struct:
     long quadrature_order
 
 cdef struct pressure_in_struct:
-    double H
-    char* asp_label
+    double updraft_top
+    char *asp_label
     double a_med
     double a_kfull
     double a_khalf
@@ -72,7 +72,7 @@ cdef struct pressure_in_struct:
     double bcoeff_tan18
     double alpha1
     double alpha2
-    double beta
+    double beta1
     double beta2
     double rd
     double w_kfull

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -82,9 +82,9 @@ cdef struct pressure_in_struct:
     double dzi
     double z_full
     double drag_sign
+    double asp_ratio
 
 cdef struct pressure_buoy_struct:
-    double asp_ratio
     double b_coeff
     double nh_pressure_b
 

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -89,8 +89,8 @@ cdef struct pressure_buoy_struct:
     double nh_pressure_b
 
 cdef struct pressure_drag_struct:
-    double nh_pressure_w1
-    double nh_pressure_w2
+    double nh_pressure_adv
+    double nh_pressure_drag
 
 cdef entr_struct entr_detr_dry(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_inverse_z(entr_in_struct entr_in) nogil

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -241,15 +241,6 @@ cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
     cdef:
         pressure_buoy_struct _ret
 
-    with gil:
-        if str(press_in.asp_label) == 'z_dependent':
-            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_kfull)/press_in.rd
-        elif str(press_in.asp_label) == 'median':
-            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_med)/press_in.rd
-        elif str(press_in.asp_label) == 'const':
-            # _ret.asp_ratio = 1.72
-            _ret.asp_ratio = 1.0
-
     _ret.b_coeff = press_in.bcoeff_tan18
     _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff
 
@@ -269,16 +260,7 @@ cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) 
     cdef:
         pressure_buoy_struct _ret
 
-    with gil:
-        if press_in.asp_label.encode('utf-8') == 'z_dependent':
-            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_kfull)/press_in.rd
-        elif press_in.asp_label.encode('utf-8') == 'median':
-            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_med)/press_in.rd
-        elif press_in.asp_label.encode('utf-8') == 'const':
-            # _ret.asp_ratio = 1.72
-            _ret.asp_ratio = 1.0
-
-    _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*_ret.asp_ratio**2 )
+    _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*press_in.asp_ratio**2 )
     _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff
 
     return _ret
@@ -287,16 +269,7 @@ cdef pressure_buoy_struct pressure_normalmode_buoysin(pressure_in_struct press_i
     cdef:
         pressure_buoy_struct _ret
 
-    with gil:
-        if press_in.asp_label.encode('utf-8') == 'z_dependent':
-            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_kfull)/press_in.rd
-        elif press_in.asp_label.encode('utf-8') == 'median':
-            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_med)/press_in.rd
-        elif press_in.asp_label.encode('utf-8') == 'const':
-            # _ret.asp_ratio = 1.72
-            _ret.asp_ratio = 1.0
-
-    _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*_ret.asp_ratio**2 )
+    _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*press_in.asp_ratio**2 )
     _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff * sin(3.14*press_in.z_full/press_in.updraft_top)
 
     return _ret

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -243,9 +243,9 @@ cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
 
     with gil:
         if str(press_in.asp_label) == 'z_dependent':
-            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
+            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_kfull)/press_in.rd
         elif str(press_in.asp_label) == 'median':
-            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_med)/press_in.rd
+            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_med)/press_in.rd
         elif str(press_in.asp_label) == 'const':
             # _ret.asp_ratio = 1.72
             _ret.asp_ratio = 1.0
@@ -271,9 +271,9 @@ cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) 
 
     with gil:
         if press_in.asp_label.encode('utf-8') == 'z_dependent':
-            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
+            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_kfull)/press_in.rd
         elif press_in.asp_label.encode('utf-8') == 'median':
-            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_med)/press_in.rd
+            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_med)/press_in.rd
         elif press_in.asp_label.encode('utf-8') == 'const':
             # _ret.asp_ratio = 1.72
             _ret.asp_ratio = 1.0
@@ -289,15 +289,15 @@ cdef pressure_buoy_struct pressure_normalmode_buoysin(pressure_in_struct press_i
 
     with gil:
         if press_in.asp_label.encode('utf-8') == 'z_dependent':
-            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_kfull)/press_in.rd
+            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_kfull)/press_in.rd
         elif press_in.asp_label.encode('utf-8') == 'median':
-            _ret.asp_ratio = press_in.H/2.0/sqrt(press_in.a_med)/press_in.rd
+            _ret.asp_ratio = press_in.updraft_top/2.0/sqrt(press_in.a_med)/press_in.rd
         elif press_in.asp_label.encode('utf-8') == 'const':
             # _ret.asp_ratio = 1.72
             _ret.asp_ratio = 1.0
 
     _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*_ret.asp_ratio**2 )
-    _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff * sin(3.14*press_in.z_full/press_in.H)
+    _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff * sin(3.14*press_in.z_full/press_in.updraft_top)
 
     return _ret
 
@@ -305,11 +305,13 @@ cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) 
     cdef:
         pressure_drag_struct _ret
 
-    _ret.nh_pressure_w1 = press_in.rho0_kfull * press_in.a_kfull * press_in.beta*press_in.w_kfull*(press_in.w_kphalf
+    _ret.nh_pressure_w1 = press_in.rho0_kfull * press_in.a_kfull * press_in.beta1*press_in.w_kfull*(press_in.w_kphalf
                           -press_in.w_khalf)*press_in.dzi
 
+    # TODO: need to test whehter the updraft_top or rd is a better length scale used in the drag term -> for now rd is used being consistent with tan18
+
     # # H based calc:  using the vertical length scale of the plume
-    # _ret.nh_pressure_w2 = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.beta2*press_in.w_kfull**2/fmax(press_in.H, 2000)
+    # _ret.nh_pressure_w2 = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.beta2*press_in.w_kfull**2/fmax(press_in.updraft_top, 2000)
 
     # rd based calc:  using the horizontal length scale of the plume -> as in tan18
     _ret.nh_pressure_w2 = -1.0 * press_in.rho0_kfull * sqrt(press_in.a_kfull) * press_in.beta2*press_in.w_kfull**2/press_in.rd

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -259,8 +259,8 @@ cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil
     cdef:
         pressure_drag_struct _ret
 
-    _ret.nh_pressure_w1 = 0.0
-    _ret.nh_pressure_w2 = -1.0 * press_in.rho0_kfull * sqrt(press_in.a_kfull) * (1.0/press_in.rd
+    _ret.nh_pressure_adv = 0.0
+    _ret.nh_pressure_drag = -1.0 * press_in.rho0_kfull * sqrt(press_in.a_kfull) * (1.0/press_in.rd
                           * (press_in.w_kfull - press_in.w_kenv)*fabs(press_in.w_kfull - press_in.w_kenv))
 
     return _ret
@@ -305,16 +305,16 @@ cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) 
     cdef:
         pressure_drag_struct _ret
 
-    _ret.nh_pressure_w1 = press_in.rho0_kfull * press_in.a_kfull * press_in.beta1*press_in.w_kfull*(press_in.w_kphalf
+    _ret.nh_pressure_adv = press_in.rho0_kfull * press_in.a_kfull * press_in.beta1*press_in.w_kfull*(press_in.w_kphalf
                           -press_in.w_khalf)*press_in.dzi
 
     # TODO: need to test whehter the updraft_top or rd is a better length scale used in the drag term -> for now rd is used being consistent with tan18
 
     # # H based calc:  using the vertical length scale of the plume
-    # _ret.nh_pressure_w2 = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.beta2*press_in.w_kfull**2/fmax(press_in.updraft_top, 2000)
+    # _ret.nh_pressure_drag = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.beta2*press_in.w_kfull**2/fmax(press_in.updraft_top, 2000)
 
     # rd based calc:  using the horizontal length scale of the plume -> as in tan18
-    _ret.nh_pressure_w2 = -1.0 * press_in.rho0_kfull * sqrt(press_in.a_kfull) * press_in.beta2*press_in.w_kfull**2/press_in.rd
+    _ret.nh_pressure_drag = -1.0 * press_in.rho0_kfull * sqrt(press_in.a_kfull) * press_in.beta2*press_in.w_kfull**2/press_in.rd
 
     return _ret
 


### PR DESCRIPTION
Main modifications:
1. coefficients used in the normal mode closure formula is renamed so that they self-explain;
2. rename the two w-related terms in the closure as "nh_pressure_adv" and "nh_pressure_drag" based on their physics;
3. keep the "pressure_buoy_coeff" in tan18 formula and leave a "TODO" so that this can later be merged into the normal mode formula by a specific set of parameters (buoy_coeff1=1./3. and buoy_coeff2=0.);
4. move the calc of 2R/H (self.asp_ratio) from turbulence_functions into Turbulent_PrognosticTKE;

Minor changes:
some data type issues