### PR TITLE
Clima master

### DIFF
--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -35,8 +35,8 @@ def main():
     paramlist_defaults['meta'] = {}
 
     paramlist_defaults['turbulence'] = {}
-    paramlist_defaults['turbulence']['prandtl_number_0'] = 1.0
     paramlist_defaults['turbulence']['Ri_bulk_crit'] = 0.2
+    paramlist_defaults['turbulence']['prandtl_number_0'] = 0.74
 
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE'] = {}
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['surface_area'] = 0.1
@@ -99,7 +99,6 @@ def Bomex(paramlist_defaults):
 
     paramlist = copy.deepcopy(paramlist_defaults)
     paramlist['meta']['casename'] = 'Bomex'
-    paramlist['turbulence']['prandtl_number_0'] = 0.74
 
     return  paramlist
 
@@ -145,7 +144,7 @@ def DYCOMS_RF01(paramlist_defaults):
     paramlist = copy.deepcopy(paramlist_defaults)
 
     paramlist['meta']['casename'] = 'DYCOMS_RF01'
-    paramlist['turbulence']['prandtl_number_0'] = 0.74
+    # paramlist['turbulence']['prandtl_number_0'] = 0.74
 
     return  paramlist
 
@@ -154,7 +153,7 @@ def GABLS(paramlist_defaults):
     paramlist = copy.deepcopy(paramlist_defaults)
 
     paramlist['meta']['casename'] = 'GABLS'
-    paramlist['turbulence']['prandtl_number_0'] = 0.74
+    # paramlist['turbulence']['prandtl_number_0'] = 0.74
     paramlist['turbulence']['EDMF_PrognosticTKE']['surface_area'] = 0.02
     return  paramlist
 

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -41,7 +41,7 @@ cdef entr_struct entr_detr_inverse_w(entr_in_struct entr_in) nogil:
 cdef entr_struct entr_detr_env_moisture_deficit(entr_in_struct entr_in) nogil:
     cdef:
         entr_struct _ret
-        double f_ent, f_det, dw2, db_p, db_m, c_det
+        double f_ent, f_det, dw2, db_p, db_m,db_a, c_det
 
     f_ent = (fmax((entr_in.RH_upd/100.0)**entr_in.sort_pow-(entr_in.RH_env/100.0)**entr_in.sort_pow,0.0))**(1/entr_in.sort_pow)
     f_det = (fmax((entr_in.RH_env/100.0)**entr_in.sort_pow-(entr_in.RH_upd/100.0)**entr_in.sort_pow,0.0))**(1/entr_in.sort_pow)
@@ -54,8 +54,9 @@ cdef entr_struct entr_detr_env_moisture_deficit(entr_in_struct entr_in) nogil:
     dw2  = fmax((entr_in.w_upd - entr_in.w_env)**2.0, 1e-2)
     db_p = fmax(entr_in.b_upd - entr_in.b_env,0.0)
     db_m = fmax(entr_in.b_env - entr_in.b_upd,0.0)
-    _ret.entr_sc = entr_in.c_ent*db_p/dw2 + c_det*f_det*db_m/dw2
-    _ret.detr_sc = entr_in.c_ent*db_m/dw2 + c_det*f_ent*db_p/dw2
+    db_a = fabs(entr_in.b_env - entr_in.b_upd)
+    _ret.entr_sc = entr_in.c_ent*db_p/dw2 + c_det*f_det*db_a/dw2
+    _ret.detr_sc = entr_in.c_ent*db_m/dw2 + c_det*f_ent*db_a/dw2
 
     return _ret
 


### PR DESCRIPTION
after consideration of the symmetric case of updraft and downdrafts (that we top not have yet) I changes the sign dependent buoyancy term in in enter/detr to be absolute value. At the same time I noticed that prandtl_number_0 was 1.0 in some case and 0.74 in others so I changed it to 0.74 in the defaults.
This has no effect on the results we have 