### PR TITLE
Changes with new turbulent entrainment, minor fixes

### DIFF
--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -44,7 +44,7 @@ def main():
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['tke_diss_coeff'] = 0.26
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['static_stab_coeff'] = 0.4
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['lambda_stab'] = 0.9
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['max_area_factor'] = 9.8
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['max_area_factor'] = 9.0
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_factor'] = 0.1
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['detrainment_factor'] = 0.5
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor'] = 0.06

--- a/thermodynamic_functions.pyx
+++ b/thermodynamic_functions.pyx
@@ -83,7 +83,7 @@ cdef double entropy_from_thetas_c(double thetas, double qt)  nogil :
 
 
 cdef  double buoyancy_c(double alpha0, double alpha)nogil  :
-    return g * (alpha - alpha0)/alpha
+    return g * (alpha - alpha0)/alpha0
 
 cdef double qv_star_c(const double p0, const double qt, const double pv) nogil  :
     return eps_v * (1.0 - qt) * pv / (p0 - pv)


### PR DESCRIPTION
1. Added turbulent entrainment to mixing length balance. 

2. Changed maximum area fraction to 9 times the surface value to avoid numerical errors. 

3. Changed buoyancy definition back to alpha-alpha_0/alpha_0.