### PR TITLE
modify pressure closure

### DIFF
--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -28,7 +28,6 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         entr_struct (*entr_detr_fp) (entr_in_struct entr_in) nogil
 
         pressure_buoy_struct (*pressure_func_buoy) (pressure_in_struct press_in) nogil
-        pressure_buoy_struct (*pressure_func_buoysin) (pressure_in_struct press_in) nogil
         pressure_drag_struct (*pressure_func_drag) (pressure_in_struct press_in) nogil
 
         bint use_const_plume_spacing

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -1406,44 +1406,51 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             input.a_med = np.median(self.UpdVar.Area.values[i,self.Gr.gw:self.Gr.nzg-self.Gr.gw][:alen])
             for k in xrange(self.Gr.gw, self.Gr.nzg-self.Gr.gw):
                 input.a_kfull = interp2pt(self.UpdVar.Area.values[i,k], self.UpdVar.Area.values[i,k+1])
-                input.dzi = self.Gr.dzi
-                input.dz = self.Gr.dz
-                input.z_full = self.Gr.z[k]
+                if input.a_kfull >= self.minimum_area:
+                    input.dzi = self.Gr.dzi
+                    input.dz = self.Gr.dz
+                    input.z_full = self.Gr.z[k]
 
-                input.a_khalf = self.UpdVar.Area.values[i,k]
-                input.a_kphalf = self.UpdVar.Area.values[i,k+1]
-                input.b_kfull = interp2pt(self.UpdVar.B.values[i,k], self.UpdVar.B.values[i,k+1])
-                input.rho0_kfull = self.Ref.rho0[k]
-                input.bcoeff_tan18 = self.pressure_buoy_coeff
-                input.alpha1 = self.pressure_normalmode_buoy_coeff1
-                input.alpha2 = self.pressure_normalmode_buoy_coeff2
-                input.beta1 = self.pressure_normalmode_adv_coeff
-                input.beta2 = self.pressure_normalmode_drag_coeff
-                input.rd = self.pressure_plume_spacing[i]
-                input.w_kfull = self.UpdVar.W.values[i,k]
-                input.w_khalf = interp2pt(self.UpdVar.W.values[i,k], self.UpdVar.W.values[i,k-1])
-                input.w_kphalf = interp2pt(self.UpdVar.W.values[i,k], self.UpdVar.W.values[i,k+1])
-                input.w_kenv = self.EnvVar.W.values[k]
-                input.drag_sign = self.drag_sign
+                    input.a_khalf = self.UpdVar.Area.values[i,k]
+                    input.a_kphalf = self.UpdVar.Area.values[i,k+1]
+                    input.b_kfull = interp2pt(self.UpdVar.B.values[i,k], self.UpdVar.B.values[i,k+1])
+                    input.rho0_kfull = self.Ref.rho0[k]
+                    input.bcoeff_tan18 = self.pressure_buoy_coeff
+                    input.alpha1 = self.pressure_normalmode_buoy_coeff1
+                    input.alpha2 = self.pressure_normalmode_buoy_coeff2
+                    input.beta1 = self.pressure_normalmode_adv_coeff
+                    input.beta2 = self.pressure_normalmode_drag_coeff
+                    input.rd = self.pressure_plume_spacing[i]
+                    input.w_kfull = self.UpdVar.W.values[i,k]
+                    input.w_kmfull = self.UpdVar.W.values[i,k-1]
+                    input.w_kenv = self.EnvVar.W.values[k]
+                    input.drag_sign = self.drag_sign
 
-                if self.asp_label == 'z_dependent':
-                    input.asp_ratio = input.updraft_top/2.0/sqrt(input.a_kfull)/input.rd
-                elif self.asp_label == 'median':
-                    input.asp_ratio = input.updraft_top/2.0/sqrt(input.a_med)/input.rd
-                elif self.asp_label == 'const':
-                    # _ret.asp_ratio = 1.72
-                    input.asp_ratio = 1.0
+                    if self.asp_label == 'z_dependent':
+                        input.asp_ratio = input.updraft_top/2.0/sqrt(input.a_kfull)/input.rd
+                    elif self.asp_label == 'median':
+                        input.asp_ratio = input.updraft_top/2.0/sqrt(input.a_med)/input.rd
+                    elif self.asp_label == 'const':
+                        # _ret.asp_ratio = 1.72
+                        input.asp_ratio = 1.0
 
-                if input.a_kfull>0.0:
-                    ret_b = self.pressure_func_buoy(input)
-                    ret_w = self.pressure_func_drag(input)
-                    self.nh_pressure_b[i,k] = ret_b.nh_pressure_b
-                    self.nh_pressure_adv[i,k] = ret_w.nh_pressure_adv
-                    self.nh_pressure_drag[i,k] = ret_w.nh_pressure_drag
+                    if input.a_kfull>0.0:
+                        ret_b = self.pressure_func_buoy(input)
+                        ret_w = self.pressure_func_drag(input)
+                        self.nh_pressure_b[i,k] = ret_b.nh_pressure_b
+                        self.nh_pressure_adv[i,k] = ret_w.nh_pressure_adv
+                        self.nh_pressure_drag[i,k] = ret_w.nh_pressure_drag
 
-                    self.b_coeff[i,k] = ret_b.b_coeff
-                    self.asp_ratio[i,k] = input.asp_ratio
+                        self.b_coeff[i,k] = ret_b.b_coeff
+                        self.asp_ratio[i,k] = input.asp_ratio
 
+                    else:
+                        self.nh_pressure_b[i,k] = 0.0
+                        self.nh_pressure_adv[i,k] = 0.0
+                        self.nh_pressure_drag[i,k] = 0.0
+
+                        self.b_coeff[i,k] = 0.0
+                        self.asp_ratio[i,k] = 0.0
                 else:
                     self.nh_pressure_b[i,k] = 0.0
                     self.nh_pressure_adv[i,k] = 0.0

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -93,9 +93,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
             if str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'tan18':
                 self.pressure_func_buoy = pressure_tan18_buoy
             elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'normalmode':
-                self.pressure_func_buoy = pressure_normalmode_buoy
-            elif str(namelist['turbulence']['EDMF_PrognosticTKE']['pressure_closure_buoy']) == 'normalmode_buoysin':
-                self.pressure_func_buoy = pressure_normalmode_buoysin
+                self.pressure_func_buoy = pressure_normalmode_buoy            
             else:
                 print('Turbulence--EDMF_PrognosticTKE: pressure closure in namelist option is not recognized')
         except:
@@ -1411,8 +1409,6 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                     input.dz = self.Gr.dz
                     input.z_full = self.Gr.z[k]
 
-                    input.a_khalf = self.UpdVar.Area.values[i,k]
-                    input.a_kphalf = self.UpdVar.Area.values[i,k+1]
                     input.b_kfull = interp2pt(self.UpdVar.B.values[i,k], self.UpdVar.B.values[i,k+1])
                     input.rho0_kfull = self.Ref.rho0[k]
                     input.bcoeff_tan18 = self.pressure_buoy_coeff

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -80,8 +80,7 @@ cdef struct pressure_in_struct:
     double beta2
     double rd
     double w_kfull
-    double w_khalf
-    double w_kphalf
+    double w_kmfull
     double w_kenv
     double dzi
     double dz

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -69,8 +69,6 @@ cdef struct pressure_in_struct:
     char *asp_label
     double a_med
     double a_kfull
-    double a_khalf
-    double a_kphalf
     double b_kfull
     double rho0_kfull
     double bcoeff_tan18
@@ -111,7 +109,6 @@ cdef buoyant_stract buoyancy_sorting_mean(entr_in_struct entr_in) nogil
 cdef pressure_buoy_struct pressure_tan18_buoy(pressure_in_struct press_in) nogil
 cdef pressure_drag_struct pressure_tan18_drag(pressure_in_struct press_in) nogil
 cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) nogil
-cdef pressure_buoy_struct pressure_normalmode_buoysin(pressure_in_struct press_in) nogil
 cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) nogil
 
 cdef double get_wstar(double bflux, double zi )

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -292,8 +292,8 @@ cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) 
     cdef:
         pressure_drag_struct _ret
 
-    _ret.nh_pressure_adv = press_in.rho0_kfull * press_in.a_kfull * press_in.beta1*press_in.w_kfull*(press_in.w_kphalf
-                          -press_in.w_khalf)*press_in.dzi
+    _ret.nh_pressure_adv = press_in.rho0_kfull * press_in.a_kfull * press_in.beta1*press_in.w_kfull*(press_in.w_kfull
+                          -press_in.w_kmfull)*press_in.dzi
 
     # drag as w_dif and account for downdrafts
     _ret.nh_pressure_drag = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.beta2 * (press_in.w_kfull -

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -279,15 +279,6 @@ cdef pressure_buoy_struct pressure_normalmode_buoy(pressure_in_struct press_in) 
 
     return _ret
 
-cdef pressure_buoy_struct pressure_normalmode_buoysin(pressure_in_struct press_in) nogil:
-    cdef:
-        pressure_buoy_struct _ret
-
-    _ret.b_coeff = press_in.alpha1 / ( 1+press_in.alpha2*press_in.asp_ratio**2 )
-    _ret.nh_pressure_b = -1.0 * press_in.rho0_kfull * press_in.a_kfull * press_in.b_kfull * _ret.b_coeff * sin(3.14*press_in.z_full/press_in.updraft_top)
-
-    return _ret
-
 cdef pressure_drag_struct pressure_normalmode_drag(pressure_in_struct press_in) nogil:
     cdef:
         pressure_drag_struct _ret


### PR DESCRIPTION
2 changes in the pressure closure:

1.  In advective term of pressure closure, the dw/dz part was computed as ( w_(k+0.5) - w_(k-0.5) )/dz. Now I change it to ( w_k - w_(k-1) )/dz;
2. The ak_full>0 criterion is added for the pressure closure.

Both modification should have minor effects. The 2nd only affects the top of updrafts.